### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/src/pytest_elasticsearch/factories.py
+++ b/src/pytest_elasticsearch/factories.py
@@ -128,7 +128,7 @@ def elasticsearch(process_fixture_name):
         if not process.running():
             process.start()
 
-        hosts = '%s:%s' % (process.host, process.port)
+        hosts = '{0!s}:{1!s}'.format(process.host, process.port)
 
         client = Elasticsearch(hosts=hosts)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:ClearcodeHQ:pytest-elasticsearch?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:ClearcodeHQ:pytest-elasticsearch?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)