### PR TITLE
replace usage of getfuncargvalue with getfixturevalue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ CHANGELOG
 unreleased
 -------
 
+- [feature] - migrate usage of getfuncargvalue to getfixturevalue. require at least pytest 3.0.0
 - [feature] - default logsdir to $TMPDIR
 - [feature] - run process on random port by default - enhances xdist experience
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def read(fname):
     return open(os.path.join(here, fname)).read()
 
 requirements = [
-    'pytest',
+    'pytest>=3.0.0',
     'mirakuru',
     'elasticsearch',
     'path.py>=6.2',

--- a/src/pytest_elasticsearch/factories.py
+++ b/src/pytest_elasticsearch/factories.py
@@ -163,7 +163,7 @@ def elasticsearch(process_fixture_name):
     @pytest.fixture
     def elasticsearch_fixture(request):
         """Elasticsearch client fixture."""
-        process = request.getfuncargvalue(process_fixture_name)
+        process = request.getfixturevalue(process_fixture_name)
         if not process.running():
             process.start()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,8 @@
 """Tests main conftest file."""
+import sys
+import warnings
+
+major, minor = sys.version_info[:2]
+
+if not (major >= 3 and minor >= 5):
+    warnings.simplefilter("error", category=DeprecationWarning)


### PR DESCRIPTION
First commit, to make sure we'll error when we'll receive DeprecationWarning about getfuncargvalue
