### PR TITLE
Add suport for newest elasticsearch version

### DIFF
--- a/.travis.install-elasticsearch.sh
+++ b/.travis.install-elasticsearch.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+function install_from_zip {
+    wget $1 -O out
+    unzip out
+    sudo mv $2 /opt/$2
+}
+
+install_from_zip https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.2.zip elasticsearch-1.5.2
+install_from_zip https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.3.zip elasticsearch-6.2.3

--- a/.travis.install-elasticsearch.sh
+++ b/.travis.install-elasticsearch.sh
@@ -6,4 +6,6 @@ function install_from_zip {
 }
 
 install_from_zip https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.2.zip elasticsearch-1.5.2
+install_from_zip https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-2.4.6.zip elasticsearch-2.4.6
+install_from_zip https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.7.zip elasticsearch-5.6.7
 install_from_zip https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.3.zip elasticsearch-6.2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: true
 language: python
 python:
 - '2.7'
@@ -19,6 +20,8 @@ install:
 - "pip install -r requirements-test.txt"
 - python setup.py $INSTALL
 - pip install pytest_elasticsearch[tests] coveralls wheel
+before_script:
+- bash .travis.install-elasticsearch.sh
 script:
 - py.test -n $XDIST --cov src/pytest_elasticsearch
 - pylama

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ branches:
   except:
   - requires-io-master
 install:
-- pip install "setuptools>=18.5.0,<30.0.0" # pypy support
+- pip install "setuptools>=18.5.0" # pypy support
 - "pip install -r requirements-test.txt"
 - python setup.py $INSTALL
 - pip install pytest_elasticsearch[tests] coveralls wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ branches:
   except:
   - requires-io-master
 install:
-- pip install "setuptools>=18.0.0,<30.0.0" # pypy support
+- pip install "setuptools>=18.5.0,<30.0.0" # pypy support
 - "pip install -r requirements-test.txt"
 - python setup.py $INSTALL
 - pip install pytest_elasticsearch[tests] coveralls wheel

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ of pytest-elasticsearch along its history.
 * Paweł Wilczyński
 * Tomasz Karbownicki
 * Karolina Blümke
+* Marcin Maślany

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ CHANGELOG
 Unreleased
 -------
 
-- [feature] - Support for elasticsearch version 6.2.3
+- [feature] - Support for major elasticsearch versions
 
 
 1.2.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+Unreleased
+-------
+
+- [feature] - Support for elasticsearch version 6.2.3
+
+
 1.2.1
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,8 @@ You can pick which you prefer, but remember that these settings are handled in t
 +----------------------+--------------------------------------+------------------------------------------------------+----------------------------------------------------+------------------------------+
 | enable zen discovery | discovery_zen_ping_multicast_enabled | --elasticsearch-discovery-zen-ping-multicast-enabled | elasticsearch_discovery_zen_ping_multicast_enabled | False                        |
 +----------------------+--------------------------------------+------------------------------------------------------+----------------------------------------------------+------------------------------+
+| transport tcp port   | transport_tcp_port                   | --elasticsearch-discovery-zen-ping-multicast-enabled | elasticsearch_transport_tcp_port                   | random                       |
++----------------------+--------------------------------------+------------------------------------------------------+----------------------------------------------------+------------------------------+
 
 Example usage:
 

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,9 @@ You can pick which you prefer, but remember that these settings are handled in t
 +----------------------+--------------------------------------+------------------------------------------------------+----------------------------------------------------+------------------------------+
 | enable zen discovery | discovery_zen_ping_multicast_enabled | --elasticsearch-discovery-zen-ping-multicast-enabled | elasticsearch_discovery_zen_ping_multicast_enabled | False                        |
 +----------------------+--------------------------------------+------------------------------------------------------+----------------------------------------------------+------------------------------+
-| transport tcp port   | transport_tcp_port                   | --elasticsearch-discovery-zen-ping-multicast-enabled | elasticsearch_transport_tcp_port                   | random                       |
+| transport tcp port   | transport_tcp_port                   | --elasticsearch-transport-tcp-port                   | elasticsearch_transport_tcp_port                   | random                       |
++----------------------+--------------------------------------+------------------------------------------------------+----------------------------------------------------+------------------------------+
+| configuration path   | configuration_path                   | --elasticsearch-configuration-path                   | elasticsearch_configuration_path                   | /etc/elasticsearch           |
 +----------------------+--------------------------------------+------------------------------------------------------+----------------------------------------------------+------------------------------+
 
 Example usage:

--- a/src/pytest_elasticsearch/factories.py
+++ b/src/pytest_elasticsearch/factories.py
@@ -133,7 +133,7 @@ def elasticsearch_proc(executable='/usr/share/elasticsearch/bin/elasticsearch',
                 --index.store.type={index_store_type}
             '''
         # it is known to work for 5.x.x; 6.x.x;
-        elif version <= ('6', '2', '3'):
+        elif version <= ('7', '0', '0'):
             return '''
                 {deamon} -p {pidfile}
                 -E http.port={port}

--- a/src/pytest_elasticsearch/factories.py
+++ b/src/pytest_elasticsearch/factories.py
@@ -100,27 +100,27 @@ def elasticsearch_proc(executable='/usr/share/elasticsearch/bin/elasticsearch',
     commands_exec = {}
     commands_exec['1.5'] = '''
         {deamon} -p {pidfile}
-        --http.port={port} \
-        --path.home={home_path} \
-        --transport.tcp.port={transport_tcp_port} \
-        --default.path.logs={logs_path} \
-        --default.path.work={work_path} \
-        --default.path.data={work_path} \
-        --default.path.conf={conf_path} \ \
-        --cluster.name={cluster} \
-        --network.publish_host='{network_publish_host}' \
-        --discovery.zen.ping.multicast.enabled={multicast_enabled} \
-        --index.store.type={index_store_type} \
+        --http.port={port}
+        --path.home={home_path}
+        --transport.tcp.port={transport_tcp_port}
+        --default.path.logs={logs_path}
+        --default.path.work={work_path}
+        --default.path.data={work_path}
+        --default.path.conf={conf_path}
+        --cluster.name={cluster}
+        --network.publish_host='{network_publish_host}'
+        --discovery.zen.ping.multicast.enabled={multicast_enabled}
+        --index.store.type={index_store_type}
     '''
     commands_exec['6.2'] = '''
-        {deamon} -p {pidfile} \
-        -E http.port={port} \
-        -E transport.tcp.port={transport_tcp_port} \
-        -E path.logs={logs_path} \
-        -E path.data={work_path} \
-        -E cluster.name={cluster} \
-        -E network.host='{network_publish_host}' \
-        -E index.store.type={index_store_type} \
+        {deamon} -p {pidfile}
+        -E http.port={port}
+        -E transport.tcp.port={transport_tcp_port}
+        -E path.logs={logs_path}
+        -E path.data={work_path}
+        -E cluster.name={cluster}
+        -E network.host='{network_publish_host}'
+        -E index.store.type={index_store_type}
     '''
 
     @pytest.fixture(scope='session')

--- a/src/pytest_elasticsearch/factories.py
+++ b/src/pytest_elasticsearch/factories.py
@@ -132,7 +132,8 @@ def elasticsearch_proc(executable='/usr/share/elasticsearch/bin/elasticsearch',
                 --network.publish_host='{network_publish_host}'
                 --index.store.type={index_store_type}
             '''
-        elif version <= ('6', '2', '3'):  # it is known to work for 5.x.x; 6.x.x;
+        # it is known to work for 5.x.x; 6.x.x;
+        elif version <= ('6', '2', '3'):
             return '''
                 {deamon} -p {pidfile}
                 -E http.port={port}

--- a/src/pytest_elasticsearch/plugin.py
+++ b/src/pytest_elasticsearch/plugin.py
@@ -84,6 +84,12 @@ def pytest_addoption(parser):
         default=None,
     )
 
+    parser.addini(
+        'elasticsearch_transport_tcp_port',
+        help='',
+        default=None
+    )
+
     parser.addoption(
         '--elasticsearch-logsdir',
         action='store',
@@ -137,6 +143,11 @@ def pytest_addoption(parser):
         help=_help_port
     )
 
+    parser.addoption(
+        '--elasticsearch-transport_tcp_port',
+        action='store',
+        dest='elasticsearch_transport_tcp_port',
+    )
 
 elasticsearch_proc = factories.elasticsearch_proc()
 elasticsearch = factories.elasticsearch('elasticsearch_proc')

--- a/src/pytest_elasticsearch/plugin.py
+++ b/src/pytest_elasticsearch/plugin.py
@@ -33,6 +33,9 @@ _help_network_publish_host = \
     'network host to which elasticsearch publish to connect to cluseter'
 _help_logs_prefix = 'prefix for the logs file'
 _help_discovery_zen_ping_multicast_enabled = 'Use zen discovery'
+_help_elasticsearch_transport_tcp_port = 'The tcp ansport port used \
+    for internal communication between nodes within the cluster'
+_help_configuration_path = 'Config file location'
 
 
 def pytest_addoption(parser):
@@ -86,13 +89,13 @@ def pytest_addoption(parser):
 
     parser.addini(
         'elasticsearch_transport_tcp_port',
-        help='',
+        help=_help_elasticsearch_transport_tcp_port,
         default=None
     )
 
     parser.addini(
         'elasticsearch_configuration_path',
-        help='',
+        help=_help_configuration_path,
         default=None
     )
 
@@ -150,7 +153,7 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
-        '--elasticsearch-transport_tcp_port',
+        '--elasticsearch-transport-tcp-port',
         action='store',
         dest='elasticsearch_transport_tcp_port',
     )

--- a/src/pytest_elasticsearch/plugin.py
+++ b/src/pytest_elasticsearch/plugin.py
@@ -90,6 +90,12 @@ def pytest_addoption(parser):
         default=None
     )
 
+    parser.addini(
+        'elasticsearch_configuration_path',
+        help='',
+        default=None
+    )
+
     parser.addoption(
         '--elasticsearch-logsdir',
         action='store',
@@ -148,6 +154,13 @@ def pytest_addoption(parser):
         action='store',
         dest='elasticsearch_transport_tcp_port',
     )
+
+    parser.addoption(
+        '--elasticsearch-configuration-path',
+        action='store',
+        dest='elasticsearch_configuration_path'
+    )
+
 
 elasticsearch_proc = factories.elasticsearch_proc()
 elasticsearch = factories.elasticsearch('elasticsearch_proc')

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -1,20 +1,51 @@
 """Pytest-elasticsearch tests."""
+import pytest
 from tempfile import gettempdir
 
 from mock import patch
 
 from pytest_elasticsearch import factories
 
+ELASTICSEARCH_EXECUTABLE_1_5_2 = '/opt/elasticsearch1.5.2/bin/elasticsearch'
+ELASTICSEARCH_EXECUTABLE_6_2_3 = '/opt/elasticsearch6.2.3/bin/elasticsearch'
 
-def test_elastic_process(elasticsearch_proc):
+elasticsearch_proc_1_5_2 = factories.elasticsearch_proc(ELASTICSEARCH_EXECUTABLE_1_5_2, port=None)
+elasticsearch_1_5_2 = factories.elasticsearch('elasticsearch_proc_1_5_2')
+
+elasticsearch_proc_6_2_3 = factories.elasticsearch_proc(ELASTICSEARCH_EXECUTABLE_6_2_3, port=None)
+elasticsearch_6_2_3 = factories.elasticsearch('elasticsearch_proc_6_2_3')
+
+
+@pytest.mark.parametrize('elasticsearch_proc_name', (
+    'elasticsearch_proc',  # this one is using system elasticsearch version
+    'elasticsearch_proc_1_5_2',
+    'elasticsearch_proc_6_2_3'
+))
+def test_elastic_process(request, elasticsearch_proc_name):
     """Simple test for starting elasticsearch_proc."""
+    elasticsearch_proc = request.getfixturevalue(elasticsearch_proc_name)
     assert elasticsearch_proc.running() is True
 
 
-def test_elasticsarch(elasticsearch):
+@pytest.mark.parametrize('elasticsearch_name', (
+    'elasticsearch',  # this one is using system elasticsearch version
+    'elasticsearch_1_5_2',
+    'elasticsearch_6_2_3'
+))
+def test_elasticsarch(request, elasticsearch_name):
     """Test if elasticsearch fixtures connects to process."""
-    info = elasticsearch.info()
-    assert info['status'] == 200
+    elasticsearch = request.getfixturevalue(elasticsearch_name)
+    info = elasticsearch.cluster.health()
+    assert info['status'] == 'green'
+
+
+@pytest.mark.parametrize('executable, expected_version', (
+    (ELASTICSEARCH_EXECUTABLE_1_5_2, '1.5.2'),
+    (ELASTICSEARCH_EXECUTABLE_6_2_3, '6.2.3')
+))
+def test_version_extraction(executable, expected_version):
+    """Verfiy if we can properly extract elasticsearch version."""
+    assert '{major}.{minor}.{patch}'.format(**factories.get_version_parts(executable)) == expected_version
 
 
 elasticsearch_proc_random = factories.elasticsearch_proc(port=None)
@@ -23,7 +54,7 @@ elasticsearch_random = factories.elasticsearch('elasticsearch_proc_random')
 
 def test_random_port(elasticsearch_random):
     """Test if elasticsearch fixture can be started on random port."""
-    assert elasticsearch_random.info()['status'] == 200
+    assert elasticsearch_random.cluster.health()['status'] == 'green'
 
 
 def test_default_configuration(request):
@@ -72,8 +103,8 @@ def test_fixture_arg_is_first(request, elasticsearch_proc_args):
     conf_dict = factories.return_config(request)
 
     port = elasticsearch_proc_args.port
-    command = elasticsearch_proc_args.command_parts
-    path_logs = '--default.path.logs=/tmp/elasticsearch_{}_logs'.format(port)
+    command = ' '.join(elasticsearch_proc_args.command_parts)
+    path_logs = 'path.logs=/tmp/elasticsearch_{}_logs'.format(port)
 
     assert conf_dict['logsdir'] == '/test1'
     assert path_logs in command

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -9,21 +9,37 @@ from pytest_elasticsearch import factories
 ELASTICSEARCH_PATH_1_5_2 = '/opt/elasticsearch-1.5.2/'
 ELASTICSEARCH_CONF_PATH_1_5_2 = ELASTICSEARCH_PATH_1_5_2 + 'config'
 ELASTICSEARCH_EXECUTABLE_1_5_2 = ELASTICSEARCH_PATH_1_5_2 + 'bin/elasticsearch'
+ELASTICSEARCH_EXECUTABLE_2_4_6 = '/opt/elasticsearch-2.4.6/bin/elasticsearch'
+ELASTICSEARCH_EXECUTABLE_5_6_7 = '/opt/elasticsearch-5.6.7/bin/elasticsearch'
 ELASTICSEARCH_EXECUTABLE_6_2_3 = '/opt/elasticsearch-6.2.3/bin/elasticsearch'
 
-elasticsearch_proc_1_5_2 = factories.elasticsearch_proc(
-    ELASTICSEARCH_EXECUTABLE_1_5_2, port=None,
-    configuration_path=ELASTICSEARCH_CONF_PATH_1_5_2
-)
-elasticsearch_1_5_2 = factories.elasticsearch('elasticsearch_proc_1_5_2')
 
-elasticsearch_proc_6_2_3 = factories.elasticsearch_proc(
-    ELASTICSEARCH_EXECUTABLE_6_2_3, port=None)
-elasticsearch_6_2_3 = factories.elasticsearch('elasticsearch_proc_6_2_3')
+def elasticsearch_fixture_factory(executable, proc_name, port, **kwargs):
+    """Create elasticsearch fixture pairs."""
+    proc = factories.elasticsearch_proc(executable, port=port, **kwargs)
+    elasticsearch = factories.elasticsearch(proc_name)
+    return proc, elasticsearch
+
+
+elasticsearch_proc_1_5_2, elasticsearch_1_5_2 = elasticsearch_fixture_factory(
+    ELASTICSEARCH_EXECUTABLE_1_5_2, 'elasticsearch_proc_1_5_2',
+    port=None, configuration_path=ELASTICSEARCH_CONF_PATH_1_5_2
+)
+elasticsearch_proc_2_4_6, elasticsearch_2_4_6 = elasticsearch_fixture_factory(
+    ELASTICSEARCH_EXECUTABLE_2_4_6, 'elasticsearch_proc_2_4_6', port=None
+)
+elasticsearch_proc_5_6_7, elasticsearch_5_6_7 = elasticsearch_fixture_factory(
+    ELASTICSEARCH_EXECUTABLE_5_6_7, 'elasticsearch_proc_5_6_7', port=None
+)
+elasticsearch_proc_6_2_3, elasticsearch_6_2_3 = elasticsearch_fixture_factory(
+    ELASTICSEARCH_EXECUTABLE_6_2_3, 'elasticsearch_proc_6_2_3', port=None
+)
 
 
 @pytest.mark.parametrize('elasticsearch_proc_name', (
     'elasticsearch_proc_1_5_2',
+    'elasticsearch_proc_2_4_6',
+    'elasticsearch_proc_5_6_7',
     'elasticsearch_proc_6_2_3'
 ))
 def test_elastic_process(request, elasticsearch_proc_name):
@@ -34,6 +50,8 @@ def test_elastic_process(request, elasticsearch_proc_name):
 
 @pytest.mark.parametrize('elasticsearch_name', (
     'elasticsearch_1_5_2',
+    'elasticsearch_2_4_6',
+    'elasticsearch_5_6_7',
     'elasticsearch_6_2_3'
 ))
 def test_elasticsarch(request, elasticsearch_name):
@@ -45,6 +63,8 @@ def test_elasticsarch(request, elasticsearch_name):
 
 @pytest.mark.parametrize('executable, expected_version', (
     (ELASTICSEARCH_EXECUTABLE_1_5_2, '1.5.2'),
+    (ELASTICSEARCH_EXECUTABLE_2_4_6, '2.4.6'),
+    (ELASTICSEARCH_EXECUTABLE_5_6_7, '5.6.7'),
     (ELASTICSEARCH_EXECUTABLE_6_2_3, '6.2.3')
 ))
 def test_version_extraction(executable, expected_version):

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -6,9 +6,9 @@ from mock import patch
 
 from pytest_elasticsearch import factories
 
-ELASTICSEARCH_PATH_1_5_2 = '/opt/elasticsearch-1.5.2/'
-ELASTICSEARCH_CONF_PATH_1_5_2 = ELASTICSEARCH_PATH_1_5_2 + 'config'
-ELASTICSEARCH_EXECUTABLE_1_5_2 = ELASTICSEARCH_PATH_1_5_2 + 'bin/elasticsearch'
+ELASTICSEARCH_CONF_PATH_1_5_2 = '/opt/elasticsearch-1.5.2/config'
+ELASTICSEARCH_CONF_PATH_2_4_6 = '/opt/elasticsearch-2.4.6/config'
+ELASTICSEARCH_EXECUTABLE_1_5_2 = '/opt/elasticsearch-1.5.2/bin/elasticsearch'
 ELASTICSEARCH_EXECUTABLE_2_4_6 = '/opt/elasticsearch-2.4.6/bin/elasticsearch'
 ELASTICSEARCH_EXECUTABLE_5_6_7 = '/opt/elasticsearch-5.6.7/bin/elasticsearch'
 ELASTICSEARCH_EXECUTABLE_6_2_3 = '/opt/elasticsearch-6.2.3/bin/elasticsearch'
@@ -26,7 +26,8 @@ elasticsearch_proc_1_5_2, elasticsearch_1_5_2 = elasticsearch_fixture_factory(
     port=None, configuration_path=ELASTICSEARCH_CONF_PATH_1_5_2
 )
 elasticsearch_proc_2_4_6, elasticsearch_2_4_6 = elasticsearch_fixture_factory(
-    ELASTICSEARCH_EXECUTABLE_2_4_6, 'elasticsearch_proc_2_4_6', port=None
+    ELASTICSEARCH_EXECUTABLE_2_4_6, 'elasticsearch_proc_2_4_6',
+    port=None, configuration_path=ELASTICSEARCH_CONF_PATH_2_4_6
 )
 elasticsearch_proc_5_6_7, elasticsearch_5_6_7 = elasticsearch_fixture_factory(
     ELASTICSEARCH_EXECUTABLE_5_6_7, 'elasticsearch_proc_5_6_7', port=None

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -6,18 +6,23 @@ from mock import patch
 
 from pytest_elasticsearch import factories
 
-ELASTICSEARCH_EXECUTABLE_1_5_2 = '/opt/elasticsearch1.5.2/bin/elasticsearch'
-ELASTICSEARCH_EXECUTABLE_6_2_3 = '/opt/elasticsearch6.2.3/bin/elasticsearch'
+ELASTICSEARCH_PATH_1_5_2 = '/opt/elasticsearch-1.5.2/'
+ELASTICSEARCH_CONF_PATH_1_5_2 = ELASTICSEARCH_PATH_1_5_2 + 'config'
+ELASTICSEARCH_EXECUTABLE_1_5_2 = ELASTICSEARCH_PATH_1_5_2 + 'bin/elasticsearch'
+ELASTICSEARCH_EXECUTABLE_6_2_3 = '/opt/elasticsearch-6.2.3/bin/elasticsearch'
 
-elasticsearch_proc_1_5_2 = factories.elasticsearch_proc(ELASTICSEARCH_EXECUTABLE_1_5_2, port=None)
+elasticsearch_proc_1_5_2 = factories.elasticsearch_proc(
+    ELASTICSEARCH_EXECUTABLE_1_5_2, port=None,
+    configuration_path=ELASTICSEARCH_CONF_PATH_1_5_2
+)
 elasticsearch_1_5_2 = factories.elasticsearch('elasticsearch_proc_1_5_2')
 
-elasticsearch_proc_6_2_3 = factories.elasticsearch_proc(ELASTICSEARCH_EXECUTABLE_6_2_3, port=None)
+elasticsearch_proc_6_2_3 = factories.elasticsearch_proc(
+    ELASTICSEARCH_EXECUTABLE_6_2_3, port=None)
 elasticsearch_6_2_3 = factories.elasticsearch('elasticsearch_proc_6_2_3')
 
 
 @pytest.mark.parametrize('elasticsearch_proc_name', (
-    'elasticsearch_proc',  # this one is using system elasticsearch version
     'elasticsearch_proc_1_5_2',
     'elasticsearch_proc_6_2_3'
 ))
@@ -28,7 +33,6 @@ def test_elastic_process(request, elasticsearch_proc_name):
 
 
 @pytest.mark.parametrize('elasticsearch_name', (
-    'elasticsearch',  # this one is using system elasticsearch version
     'elasticsearch_1_5_2',
     'elasticsearch_6_2_3'
 ))
@@ -45,10 +49,15 @@ def test_elasticsarch(request, elasticsearch_name):
 ))
 def test_version_extraction(executable, expected_version):
     """Verfiy if we can properly extract elasticsearch version."""
-    assert '{major}.{minor}.{patch}'.format(**factories.get_version_parts(executable)) == expected_version
+    assert '{major}.{minor}.{patch}'.format(
+        **factories.get_version_parts(executable)
+    ) == expected_version
 
 
-elasticsearch_proc_random = factories.elasticsearch_proc(port=None)
+elasticsearch_proc_random = factories.elasticsearch_proc(
+    ELASTICSEARCH_EXECUTABLE_1_5_2, port=None,
+    configuration_path=ELASTICSEARCH_CONF_PATH_1_5_2
+)
 elasticsearch_random = factories.elasticsearch('elasticsearch_proc_random')
 
 
@@ -92,7 +101,10 @@ def test_ini_option_configuration(request):
 
 
 elasticsearch_proc_args = factories.elasticsearch_proc(
-    port=None, elasticsearch_logsdir='/tmp')
+    ELASTICSEARCH_EXECUTABLE_1_5_2,
+    configuration_path=ELASTICSEARCH_CONF_PATH_1_5_2,
+    port=None, elasticsearch_logsdir='/tmp'
+)
 
 
 @patch('pytest_elasticsearch.plugin.pytest.config')


### PR DESCRIPTION
This adds support for recent elasticsearch version 6.2.3. 

Some of the configs were renamed/removed in the 6.2.3 version. I didn't modify the parameters we pass to the fixture factory for the sake of compatibility. This roughly means that same configuration will run both on 1.5.2 and 6.2.3, but the fixture factory variable names are passed as in 1.5.2 (those are tiny differences like: `network_publish_host` instead of `network_host`. The proper variable renames or ignore are handled in the factory. 

Needs modification of the CI though to have both versions.