### PR TITLE
Pipe stderr to stdout to better display issues

### DIFF
--- a/src/pytest_elasticsearch/executor.py
+++ b/src/pytest_elasticsearch/executor.py
@@ -81,7 +81,10 @@ class ElasticSearchExecutor(HTTPExecutor):
         """
         if not self._version:
             try:
-                output = check_output([self.executable, '-Vv'], stderr=STDOUT).decode('utf-8')
+                output = check_output(
+                    [self.executable, '-Vv'],
+                    stderr=STDOUT,
+                ).decode('utf-8')
                 match = re.search(
                     r'Version: (?P<major>\d)\.(?P<minor>\d)\.(?P<patch>\d+)',
                     output

--- a/src/pytest_elasticsearch/executor.py
+++ b/src/pytest_elasticsearch/executor.py
@@ -1,7 +1,7 @@
 """Elasticsearch executor."""
 
 import re
-from subprocess import check_output
+from subprocess import check_output, STDOUT
 
 from mirakuru import HTTPExecutor
 from pkg_resources import parse_version
@@ -81,7 +81,7 @@ class ElasticSearchExecutor(HTTPExecutor):
         """
         if not self._version:
             try:
-                output = check_output([self.executable, '-Vv']).decode('utf-8')
+                output = check_output([self.executable, '-Vv'], stderr=STDOUT).decode('utf-8')
                 match = re.search(
                     r'Version: (?P<major>\d)\.(?P<minor>\d)\.(?P<patch>\d+)',
                     output

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -87,7 +87,7 @@ def test_version_extraction(output, expected_version):
     """Verify if we can properly extract elasticsearch version."""
     with mock.patch(
             'pytest_elasticsearch.executor.check_output',
-            lambda *args: output.encode('utf8')
+            lambda *args, **kwargs: output.encode('utf8')
     ):
         executor = ElasticSearchExecutor(
             'elasticsearch',


### PR DESCRIPTION
When using `pytest-elasticsearch` in a a docker image setting, I had multiple issues that could be solved much faster if the failing ES process' output was visible.

In this PR I attempt to do so by piping stderr to stdout as (I think) stdout is already displayed on error.

The issue was due to configurations in the image and I couldn't reproduce it locally.

In my local testing, I've used the following sinppet in order to debug it:
```python
import subprocess
raise Exception(subprocess.run(["/path/to/es/executable", "-Vv"], stderr=subprocess.STDOUT, check=False, stdout=subprocess.PIPE).stdout.decode("utf-8"))
```