### PR TITLE
fixes version regex so it works with latest and future versions

### DIFF
--- a/src/pytest_elasticsearch/executor.py
+++ b/src/pytest_elasticsearch/executor.py
@@ -83,7 +83,7 @@ class ElasticSearchExecutor(HTTPExecutor):
             try:
                 output = check_output([self.executable, '-Vv']).decode('utf-8')
                 match = re.search(
-                    r'Version: (?P<major>\d)\.(?P<minor>\d)\.(?P<patch>\d+)',
+                    r'Version: (?P<major>\d)\.(?P<minor>\d+)\.(?P<patch>\d+)',
                     output
                 )
                 if not match:


### PR DESCRIPTION
Ran into it today with latest elastic search. Tested it out and fixes the issue. Basically 2 digit minor versions aren't supported.