### PR TITLE
Support elasticsearch 8.9 - closes #416

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  tests_8_6:
+  tests_8_9:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -22,9 +22,9 @@ jobs:
       - uses: ./.github/actions/pytest
         with:
           python-version: ${{ matrix.python-version }}
-          elasticsearch: "8.6"
-  tests_8_5:
-    needs: [tests_8_6]
+          elasticsearch: "8.9"
+  tests_8_8:
+    needs: [tests_8_9]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -39,9 +39,9 @@ jobs:
       - uses: ./.github/actions/pytest
         with:
           python-version: ${{ matrix.python-version }}
-          elasticsearch: "8.5"
-  tests_8_4:
-    needs: [tests_8_5]
+          elasticsearch: "8.8"
+  tests_8_7:
+    needs: [tests_8_8]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -56,9 +56,60 @@ jobs:
       - uses: ./.github/actions/pytest
         with:
           python-version: ${{ matrix.python-version }}
+          elasticsearch: "8.6"
+  tests_8_6:
+    needs: [tests_8_7]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.10", "3.11"]
+    env:
+      OS: ubuntu-latest
+      PYTHON: ${{ matrix.python-version }}
+      ES_JAVA_OPTS: "-Xms256m -Xmx512m"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pytest
+        with:
+          python-version: ${{ matrix.python-version }}
+          elasticsearch: "8.6"
+  tests_8_5:
+    needs: [tests_8_7]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.10", "3.11"]
+    env:
+      OS: ubuntu-latest
+      PYTHON: ${{ matrix.python-version }}
+      ES_JAVA_OPTS: "-Xms256m -Xmx512m"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pytest
+        with:
+          python-version: ${{ matrix.python-version }}
+          elasticsearch: "8.5"
+  tests_8_4:
+    needs: [tests_8_7]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.11"]
+    env:
+      OS: ubuntu-latest
+      PYTHON: ${{ matrix.python-version }}
+      ES_JAVA_OPTS: "-Xms256m -Xmx512m"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pytest
+        with:
+          python-version: ${{ matrix.python-version }}
           elasticsearch: "8.4"
   tests_8_3:
-    needs: [tests_8_4]
+    needs: [tests_8_7]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -74,47 +125,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           elasticsearch: "8.3"
-  tests_8_2:
-    needs: [tests_8_4]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ["3.11"]
-    env:
-      OS: ubuntu-latest
-      PYTHON: ${{ matrix.python-version }}
-      ES_JAVA_OPTS: "-Xms256m -Xmx512m"
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/pytest
-        with:
-          python-version: ${{ matrix.python-version }}
-          elasticsearch: "8.2"
-  tests_8_1:
-    needs: [tests_8_4]
+  tests_8_0:
+    needs: [tests_8_7]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
         python-version: ["3.10", "3.11"]
-    env:
-      OS: ubuntu-latest
-      PYTHON: ${{ matrix.python-version }}
-      ES_JAVA_OPTS: "-Xms256m -Xmx512m"
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/pytest
-        with:
-          python-version: ${{ matrix.python-version }}
-          elasticsearch: "8.1"
-  tests_8_0:
-    needs: [tests_8_4]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ["3.11"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -130,7 +147,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", pypy-3.8]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -140,51 +157,3 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           elasticsearch: "7.17"
-  tests_7_16:
-    needs: [tests_7_17]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ["3.11"]
-    env:
-      OS: ubuntu-latest
-      PYTHON: ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/pytest
-        with:
-          python-version: ${{ matrix.python-version }}
-          elasticsearch: "7.16"
-  tests_7_15:
-    needs: [tests_7_17]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ["3.11"]
-    env:
-      OS: ubuntu-latest
-      PYTHON: ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/pytest
-        with:
-          python-version: ${{ matrix.python-version }}
-          elasticsearch: "7.15"
-  tests_7_14:
-    needs: [tests_7_17]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ["3.11"]
-    env:
-      OS: ubuntu-latest
-      PYTHON: ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/pytest
-        with:
-          python-version: ${{ matrix.python-version }}
-          elasticsearch: "7.14"

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 pytest = "==7.3.2"
 port-for = "==0.7.0"
 mirakuru = "==2.5.1"
-elasticsearch = "==8.6"
+elasticsearch = "==8.9"
 
 [dev-packages]
 towncrier = "==23.6.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c7b2c19017aee3ebe5aa0f84bb9a9dbfa5af8497469a1ae9a8633d0a1a88d4f8"
+            "sha256": "0f8f050791574c8d09cd68c395845e9c9eefe3336527719cf7ccf8f122f99e19"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -32,11 +32,11 @@
         },
         "elasticsearch": {
             "hashes": [
-                "sha256:70f6da78878c5df28cd4a4b902a57192a86b0306e69bc08177a14dac9759db59",
-                "sha256:9d2c1010bda4699c202be82cb960aee3fb9359ca98bb83dfa7db06679212e9a7"
+                "sha256:0795cbf0f61482070741c09ba02ac8fdf18f5984912fbd08b248fadd8a8c9952",
+                "sha256:d3367fc013e04fc7aad349a6de9fad1ee04fb6d627b0e7896aa505c12fde5e04"
             ],
             "index": "pypi",
-            "version": "==8.6"
+            "version": "==8.9"
         },
         "iniconfig": {
             "hashes": [

--- a/newsfragments/384.feature.rst
+++ b/newsfragments/384.feature.rst
@@ -1,1 +1,1 @@
-Support elasticsearch up to 8.6
+Support elasticsearch up to 8.9

--- a/newsfragments/384.misc.rst
+++ b/newsfragments/384.misc.rst
@@ -1,0 +1,1 @@
+Dropped Elasticsearch older than 7.17 from CI.


### PR DESCRIPTION
Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number