### PR TITLE
Support Python 3.13, drop support for Python 3.8

### DIFF
--- a/.github/actions/elastic_7/action.yml
+++ b/.github/actions/elastic_7/action.yml
@@ -35,7 +35,7 @@ runs:
     shell: bash
     run: pipenv run pytest --elasticsearch-executable=$ES_HOME/bin/elasticsearch -n 1 --cov-report=xml:coverage-xdist.xml
   - name: Upload coverage to Codecov
-    uses: codecov/codecov-action@v4
+    uses: codecov/codecov-action@v5
     with:
       flags: linux,elastic-${{ inputs.elasticsearch }}
       env_vars: OS, PYTHON

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -23,17 +23,17 @@ runs:
     with:
       elasticsearch-version: ${{ inputs.elasticsearch }}
   - name: Run test
-    uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.4
+    uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.8
     with:
       python-version: ${{ matrix.python-version }}
       command: pytest --elasticsearch-executable=$ES_HOME/bin/elasticsearch -n 0 --cov-report=xml
   - name: Run xdist test
-    uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.4
+    uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.8
     with:
       python-version: ${{ matrix.python-version }}
       command: pytest --elasticsearch-executable=$ES_HOME/bin/elasticsearch -n 1 --cov-report=xml:coverage-xdist.xml
   - name: Upload coverage to Codecov
-    uses: codecov/codecov-action@v4
+    uses: codecov/codecov-action@v5
     with:
       flags: linux,elastic-${{ inputs.elasticsearch }}
       env_vars: OS, PYTHON

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.8
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           command: tbump --dry-run --only-patch $(pipenv run tbump current-version)"-x"
   towncrier:
     runs-on: ubuntu-latest
@@ -20,6 +20,6 @@ jobs:
     steps:
       - uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.8
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           command: towncrier check --compare-with origin/main
           fetch-depth: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", pypy-3.9]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", pypy-3.9]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10", "3.11", "3.12", pypy-3.9]
+        python-version: ["3.11", "3.12", "3.13", "pypy-3.10"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}

--- a/newsfragments/+b00fa191.feature.rst
+++ b/newsfragments/+b00fa191.feature.rst
@@ -1,0 +1,1 @@
+Marked support for Python 3.13

--- a/newsfragments/+f5563a02.break.rst
+++ b/newsfragments/+f5563a02.break.rst
@@ -1,0 +1,1 @@
+Dropped support for Python 3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Testing",
@@ -33,7 +33,7 @@ dependencies = [
     "mirakuru",
     "elasticsearch >= 7",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 
 [project.urls]
 "Source" = "https://github.com/ClearcodeHQ/pytest-elasticsearch"
@@ -62,7 +62,7 @@ testpaths = "tests"
 
 [tool.black]
 line-length = 100
-target-version = ['py38']
+target-version = ['py39']
 include = '.*\.pyi?$'
 
 [tool.ruff]


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number