### PR TITLE
Pin elasticsearch 17 to specific version in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           elasticsearch: "8.11"
   tests_7_17:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:
@@ -125,7 +125,7 @@ jobs:
           elasticsearch: "7.17"
   tests_7_17_lib_7:
     needs: [tests_7_17]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:

--- a/newsfragments/+815af828.misc.rst
+++ b/newsfragments/+815af828.misc.rst
@@ -1,0 +1,1 @@
+Pin elasticsearch 17 tests to ubuntu 22.04, as 24.04 had some issues running elasticsearch 17.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number